### PR TITLE
Add SMS compliance contact and privacy policy updates

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,8 +4,21 @@ import Hero from "./components/Hero";
 import Products from "./components/Products";
 import About from "./components/About";
 import Contact from "./components/Contact";
+import PrivacyPolicy from "./components/PrivacyPolicy";
 
 function App() {
+  const isPrivacyPolicy =
+    window.location.pathname.replace(/\/+$/, "") === "/privacy-policy";
+
+  if (isPrivacyPolicy) {
+    return (
+      <div className="App">
+        <Navbar />
+        <PrivacyPolicy />
+      </div>
+    );
+  }
+
   return (
     <div className="App">
       <Navbar />

--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -43,12 +43,14 @@ const Contact = () => {
                     >
                       (732) 781-8102
                     </a>
-                    <div className="mt-3 flex items-center gap-2 text-sm text-gray-600">
-                      <MessageCircle className="text-teal-600" size={16} />
-                      <span>SMS:</span>
+                    <div className="mt-4">
+                      <div className="flex items-center gap-2 text-sm text-gray-600 mb-1">
+                        <MessageCircle className="text-teal-600" size={16} />
+                        <span>SMS</span>
+                      </div>
                       <a
                         href="tel:+13252695223"
-                        className="font-bold text-teal-700 hover:text-teal-800"
+                        className="text-teal-600 font-bold text-2xl hover:text-teal-700 block"
                       >
                         325-269-5223
                       </a>

--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -26,25 +26,33 @@ const Contact = () => {
             </h3>
 
             <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-8">
-              {/* SMS Phone */}
+              {/* Phone */}
               <div className="bg-white rounded-xl p-6 shadow-sm border border-teal-100">
                 <div className="flex items-start gap-4">
                   <div className="bg-teal-100 p-3 rounded-lg">
-                    <MessageCircle className="text-teal-600" size={24} />
+                    <Phone className="text-teal-600" size={24} />
                   </div>
                   <div className="flex-1">
-                    <h4 className="font-bold text-gray-900 mb-2">
-                      SMS Business Line
-                    </h4>
+                    <h4 className="font-bold text-gray-900 mb-2">Phone</h4>
                     <p className="text-gray-600 text-sm mb-2">
-                      Vonage verification number
+                      Call or WhatsApp
                     </p>
                     <a
-                      href="tel:+13252695223"
-                      className="text-teal-600 font-bold text-2xl hover:text-teal-700"
+                      href="tel:+17327818102"
+                      className="text-teal-600 font-bold text-2xl hover:text-teal-700 block"
                     >
-                      325-269-5223
+                      (732) 781-8102
                     </a>
+                    <div className="mt-3 flex items-center gap-2 text-sm text-gray-600">
+                      <MessageCircle className="text-teal-600" size={16} />
+                      <span>SMS:</span>
+                      <a
+                        href="tel:+13252695223"
+                        className="font-bold text-teal-700 hover:text-teal-800"
+                      >
+                        325-269-5223
+                      </a>
+                    </div>
                   </div>
                 </div>
               </div>

--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -1,14 +1,14 @@
 // Contact.jsx - Updated Light Theme
 import React from "react";
-import { Phone, Mail, MapPin } from "lucide-react";
+import { MessageCircle, Mail, MapPin, Phone } from "lucide-react";
 
 const Contact = () => {
-
-
   return (
-    <section id="contact" className="py-20 bg-gradient-to-b from-white to-teal-50">
+    <section
+      id="contact"
+      className="py-20 bg-gradient-to-b from-white to-teal-50"
+    >
       <div className="max-w-7xl mx-auto px-4">
-        
         {/* Header */}
         <div className="text-center mb-16">
           <h2 className="text-4xl md:text-5xl font-bold text-gray-900 mb-4">
@@ -20,28 +20,30 @@ const Contact = () => {
         </div>
 
         <div className="mb-12">
-          
-          <div className="max-w-5xl mx-auto">
+          <div className="max-w-6xl mx-auto">
             <h3 className="text-3xl font-bold text-gray-900 mb-8 text-center">
               Get In Touch
             </h3>
 
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-              
-              {/* Phone */}
+            <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-8">
+              {/* SMS Phone */}
               <div className="bg-white rounded-xl p-6 shadow-sm border border-teal-100">
                 <div className="flex items-start gap-4">
                   <div className="bg-teal-100 p-3 rounded-lg">
-                    <Phone className="text-teal-600" size={24} />
+                    <MessageCircle className="text-teal-600" size={24} />
                   </div>
                   <div className="flex-1">
-                    <h4 className="font-bold text-gray-900 mb-2">Phone</h4>
-                    <p className="text-gray-600 text-sm mb-2">Call or WhatsApp</p>
-                    <a 
-                      href="tel:+17327818102" 
+                    <h4 className="font-bold text-gray-900 mb-2">
+                      SMS Business Line
+                    </h4>
+                    <p className="text-gray-600 text-sm mb-2">
+                      Vonage verification number
+                    </p>
+                    <a
+                      href="tel:+13252695223"
                       className="text-teal-600 font-bold text-2xl hover:text-teal-700"
                     >
-                      (732) 781-8102
+                      325-269-5223
                     </a>
                   </div>
                 </div>
@@ -56,8 +58,10 @@ const Contact = () => {
                   <div className="flex-1">
                     <h4 className="font-bold text-gray-900 mb-2">Email</h4>
                     <p className="text-gray-600 text-sm">
-                      info@aafoods.us<br />
-                      dallas@aafoods.us<br />
+                      info@aafoods.us
+                      <br />
+                      dallas@aafoods.us
+                      <br />
                       gw@aafoods.us
                     </p>
                   </div>
@@ -65,18 +69,62 @@ const Contact = () => {
               </div>
 
               {/* Locations */}
-              <div className="bg-white rounded-xl p-6 shadow-sm border border-teal-100">
+              <div className="bg-white rounded-xl p-6 shadow-sm border border-teal-100 md:col-span-2 xl:col-span-1">
                 <div className="flex items-start gap-4">
                   <div className="bg-teal-100 p-3 rounded-lg">
                     <MapPin className="text-teal-600" size={24} />
                   </div>
                   <div className="flex-1">
-                    <h4 className="font-bold text-gray-900 mb-2">Our Locations</h4>
-                    <p className="text-gray-600 text-sm leading-relaxed">
-                      <strong>Detroit:</strong> Farmington Hills, MI<br />
-                      <strong>Dallas:</strong> Dallas, TX<br />
-                      <strong>Plant:</strong> Goldthwaite, TX
-                    </p>
+                    <h4 className="font-bold text-gray-900 mb-2">
+                      Our Locations
+                    </h4>
+                    <div className="space-y-4 text-gray-600 text-sm leading-relaxed">
+                      <address className="not-italic">
+                        <strong className="text-gray-900">Detroit:</strong>{" "}
+                        23985 Industrial Park Dr, Farmington Hills, MI 48335
+                        <br />
+                        <Phone
+                          className="inline-block text-teal-600 mr-1"
+                          size={14}
+                        />
+                        <a
+                          href="tel:+17327818102"
+                          className="font-semibold text-teal-700 hover:text-teal-800"
+                        >
+                          (732) 781-8102
+                        </a>
+                      </address>
+                      <address className="not-italic">
+                        <strong className="text-gray-900">Dallas:</strong> 818
+                        Metromedia Pl, Dallas, TX 75247
+                        <br />
+                        <Phone
+                          className="inline-block text-teal-600 mr-1"
+                          size={14}
+                        />
+                        <a
+                          href="tel:+14694188075"
+                          className="font-semibold text-teal-700 hover:text-teal-800"
+                        >
+                          (469) 418-8075
+                        </a>
+                      </address>
+                      <address className="not-italic">
+                        <strong className="text-gray-900">Plant:</strong> 1110 E
+                        Front St, Goldthwaite, TX 76844
+                        <br />
+                        <Phone
+                          className="inline-block text-teal-600 mr-1"
+                          size={14}
+                        />
+                        <a
+                          href="tel:+13252695223"
+                          className="font-semibold text-teal-700 hover:text-teal-800"
+                        >
+                          325-269-5223
+                        </a>
+                      </address>
+                    </div>
                   </div>
                 </div>
               </div>
@@ -84,18 +132,32 @@ const Contact = () => {
 
             {/* Serving USA Badge */}
             <div className="bg-teal-500 rounded-xl p-6 text-center text-white mt-8">
-              <p className="text-lg font-bold">📍 Serving the Entire USA</p>
+              <p className="text-lg font-bold">Serving the Entire USA</p>
             </div>
           </div>
-
         </div>
-
       </div>
 
       {/* Footer */}
       <div className="max-w-7xl mx-auto px-4 pt-12 border-t border-teal-200 text-center">
+        <p className="text-gray-600 text-sm mb-3">
+          <a
+            href="/privacy-policy"
+            className="text-teal-700 font-semibold hover:text-teal-800"
+          >
+            Privacy Policy
+          </a>
+          <span className="mx-2">|</span>
+          <a
+            href="/privacy-policy"
+            className="text-teal-700 font-semibold hover:text-teal-800"
+          >
+            SMS Terms
+          </a>
+        </p>
         <p className="text-gray-600 text-sm">
-          © 2024 Asian American Foods. All Rights Reserved. | HALAL Certified | USDA Approved
+          © 2024 Asian American Foods. All Rights Reserved. | HALAL Certified |
+          USDA Approved
         </p>
       </div>
     </section>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -34,6 +34,8 @@ const Navbar = () => {
         behavior: "smooth",
       });
       setIsOpen(false);
+    } else {
+      window.location.href = `/${href}`;
     }
   };
 

--- a/src/components/PrivacyPolicy.jsx
+++ b/src/components/PrivacyPolicy.jsx
@@ -1,0 +1,129 @@
+import React from "react";
+import { ArrowLeft, MessageCircle, Phone } from "lucide-react";
+
+const PrivacyPolicy = () => {
+  return (
+    <main className="pt-20 bg-gradient-to-b from-white to-teal-50 min-h-screen">
+      <section className="py-16 md:py-20">
+        <div className="max-w-4xl mx-auto px-4">
+          <a
+            href="/#contact"
+            className="inline-flex items-center gap-2 text-teal-700 hover:text-teal-800 font-semibold mb-8"
+          >
+            <ArrowLeft size={18} />
+            Back to Contact
+          </a>
+
+          <div className="bg-white border border-teal-100 rounded-2xl shadow-sm p-8 md:p-12">
+            <p className="text-sm font-semibold text-teal-600 uppercase tracking-wide mb-3">
+              Asian American Foods
+            </p>
+            <h1 className="text-4xl md:text-5xl font-bold text-gray-900 mb-6">
+              Privacy Policy
+            </h1>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-10">
+              <div className="bg-teal-50 border border-teal-100 rounded-xl p-5">
+                <div className="flex items-center gap-2 text-teal-700 font-bold mb-2">
+                  <MessageCircle size={20} />
+                  SMS Business Line
+                </div>
+                <a
+                  href="tel:+13252695223"
+                  className="text-2xl font-black text-gray-900 hover:text-teal-700"
+                >
+                  325-269-5223
+                </a>
+              </div>
+              <div className="bg-gray-50 border border-gray-100 rounded-xl p-5">
+                <div className="flex items-center gap-2 text-gray-700 font-bold mb-2">
+                  <Phone size={20} />
+                  General Business Line
+                </div>
+                <a
+                  href="tel:+17327818102"
+                  className="text-2xl font-black text-gray-900 hover:text-teal-700"
+                >
+                  (732) 781-8102
+                </a>
+              </div>
+            </div>
+
+            <div className="space-y-8 text-gray-700 leading-relaxed">
+              <section>
+                <h2 className="text-2xl font-bold text-gray-900 mb-3">
+                  SMS Privacy Policy & Terms of Service
+                </h2>
+                <p>
+                  By providing your phone number to Asian American Foods, you
+                  agree to receive text messages from us regarding your
+                  wholesale inquiries, order confirmations, and delivery
+                  updates. Message and data rates may apply. Message frequency
+                  varies. You can reply STOP at any time to opt-out of future
+                  messaging.
+                </p>
+              </section>
+
+              <section>
+                <h2 className="text-2xl font-bold text-gray-900 mb-3">
+                  Privacy Protection
+                </h2>
+                <p>
+                  Mobile information shared for SMS consent will not be shared
+                  with third parties or affiliates for marketing or promotional
+                  purposes. This excludes text messaging originator opt-in data
+                  and consent; this information will not be shared with any
+                  third parties.
+                </p>
+              </section>
+
+              <section>
+                <h2 className="text-2xl font-bold text-gray-900 mb-3">
+                  Business Locations
+                </h2>
+                <div className="grid grid-cols-1 gap-4">
+                  <div className="border border-gray-100 rounded-xl p-5">
+                    <h3 className="font-bold text-gray-900 mb-1">
+                      Detroit / Farmington Hills
+                    </h3>
+                    <p>23985 Industrial Park Dr, Farmington Hills, MI 48335</p>
+                    <a
+                      href="tel:+17327818102"
+                      className="text-teal-700 font-semibold hover:text-teal-800"
+                    >
+                      (732) 781-8102
+                    </a>
+                  </div>
+                  <div className="border border-gray-100 rounded-xl p-5">
+                    <h3 className="font-bold text-gray-900 mb-1">Dallas</h3>
+                    <p>818 Metromedia Pl, Dallas, TX 75247</p>
+                    <a
+                      href="tel:+14694188075"
+                      className="text-teal-700 font-semibold hover:text-teal-800"
+                    >
+                      (469) 418-8075
+                    </a>
+                  </div>
+                  <div className="border border-gray-100 rounded-xl p-5">
+                    <h3 className="font-bold text-gray-900 mb-1">
+                      Plant / Goldthwaite
+                    </h3>
+                    <p>1110 E Front St, Goldthwaite, TX 76844</p>
+                    <a
+                      href="tel:+13252695223"
+                      className="text-teal-700 font-semibold hover:text-teal-800"
+                    >
+                      325-269-5223
+                    </a>
+                  </div>
+                </div>
+              </section>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+};
+
+export default PrivacyPolicy;


### PR DESCRIPTION
## Summary
- Add full physical addresses and location phone numbers to the Contact section
- Mark 325-269-5223 as the Vonage SMS business verification number
- Add a dedicated /privacy-policy page with SMS Privacy Policy & Terms of Service language
- Add footer links for Privacy Policy and SMS Terms

## Verification
- npm run build
- Browser checked http://localhost:3000/#contact for the updated addresses, SMS number, and footer policy links
- Browser checked http://localhost:3000/privacy-policy for the SMS terms language and SMS business number

Note: no direct push was made to main. This PR is ready for manual review and merge.